### PR TITLE
Add custom working directory value to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 |-----------------|-----------------------------------------------------------------------------------------------------------------|----------|
 | `timeout`       | Duration (in minutes) before the test is terminated. Defaults to 10 minutes with a maximum limit of 6 hours.    | Yes      |
 | `max-score`     | Points to be awarded if the test passes.                                                                        | No       |
-| `setup-command`         | Command to execute prior to the test, typically for environment setup or dependency installation.                                                                | No       |
+| `setup-command`         | Command to execute prior to the test, typically for environment setup or dependency installation.       | No       |
+| `working-directory`     | Relative location where pytest should start looking for tests.                                          | No       |
 
 ### Outputs
 
@@ -47,6 +48,7 @@ jobs:
         timeout: '15'
         max-score: '100'
         setup-command: 'pip install -r requirements.txt'
+        working-directory: 'some_subdir'
     - name: Autograding Reporter
       uses: ...
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   setup-command:
     description: "Command to execute prior to the test, typically for environment setup or dependency installation."
     required: false
+  working-directory:
+    description: "Working directory to start the test."
+    required: false
 outputs:
   result:
     description: "Runner output"
@@ -23,3 +26,4 @@ runs:
     - "--timeout=${{ inputs.timeout }}"
     - "--max-score=${{ inputs.max-score }}"
     - "--setup-command=${{ inputs.setup-command }}"
+    - "--working-directory=${{ inputs.working-directory }}"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -3,7 +3,7 @@
 root="/opt/test-runner"
 export PYTHONPATH="$root:$PYTHONPATH"
 
-mkdir autograding_output
+mkdir -p autograding_output
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -16,6 +16,9 @@ while [ $# -gt 0 ]; do
       ;;
     --setup-command=*)
       SETUP_COMMAND="${1#*=}"
+      ;;
+    --working-directory=*)
+      WORKING_DIR="${1#*=}"
       ;;
     *)
       printf "***************************\n"
@@ -34,7 +37,7 @@ if [ -n "$SETUP_COMMAND" ]; then
   eval "$SETUP_COMMAND"
 fi
 
-timeout "$TIMEOUT" python3 /opt/test-runner/bin/run.py ./ ./autograding_output/ "$MAX_SCORE"
+timeout "$TIMEOUT" python3 /opt/test-runner/bin/run.py ./$WORKING_DIR ./autograding_output/ "$MAX_SCORE"
 exit_status=$?
 if [ $exit_status -eq 124 ]; then
   echo "The command took longer than $TIMEOUT seconds to execute. Please increase the timeout to avoid this error."


### PR DESCRIPTION
Small update allowing to change the location (relative to the tested repository) where pytest should start to look for tests.

I had a case where I wanted to have separate graders for subprojects, like my tree structure:
```
.
├── zadanie_1
│   └── tests
├── zadanie_2
│   └── tests
└── zadanie_3
    └── tests
```
and I wanted to run grader in each subdirectory separately:
```yml
    steps:
    - name: Checkout code
      uses: actions/checkout@v4
    - name: Python Test - Zadanie 1
      id: test-zadanie-1
      uses: rlalik/autograding-python-grader@v1.1
      with:
        timeout: 10
        max-score: 1.5
        working-directory: zadanie_1
    - name: Python Test - Zadanie 2
      id: test-zadanie-2
      uses: rlalik/autograding-python-grader@v1.1
      with:
        timeout: 10
        max-score: 2
        setup-command: pip install -r requirements.txt
        working-directory: zadanie_2
    - name: Python Test - Zadanie 3
      id: test-zadanie-3
      uses: rlalik/autograding-python-grader@v1.1
      with:
        timeout: 10
        max-score: 1.5
        working-directory: zadanie_3
    - name: Autograding Reporter
      uses: classroom-resources/autograding-grading-reporter@v1
      env:
        TEST-ZADANIE-1_RESULTS: "${{steps.test-zadanie-1.outputs.result}}"
        TEST-ZADANIE-2_RESULTS: "${{steps.test-zadanie-2.outputs.result}}"
        TEST-ZADANIE-3_RESULTS: "${{steps.test-zadanie-3.outputs.result}}"
      with:
        runners: test-zadanie-1,test-zadanie-2,test-zadanie-3
```

giving following summary:
```
| Test runner summary
| ┌────────────────────┬─────────────┬─────────────┐
| │ Test Runner Name   │ Test Score  │ Max Score   │
| ├────────────────────┼─────────────┼─────────────┤
| │ test-zadanie-1     │ 1.5         │ 1.5         │
| ├────────────────────┼─────────────┼─────────────┤
| │ test-zadanie-2     │ 1.2         │ 2           │
| ├────────────────────┼─────────────┼─────────────┤
| │ test-zadanie-3     │ 1.5         │ 1.5         │
| ├────────────────────┼─────────────┼─────────────┤
| │ Total:             │ 4.2         │ 5           │
| └────────────────────┴─────────────┴─────────────┘
| 🏆 Grand total tests passed: 15/16
```