### PR TITLE
Allow max_score to be float

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -39,7 +39,7 @@ def main():
     parser.add_argument(
         "max_score",
         metavar="MAX",
-        type=int,
+        type=float,
         help="max amount of points the test suite is worth",
     )
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -140,7 +140,7 @@ class ResultsReporter:
             if test.is_passing():
                 test.score = self.results.max_score / len(self.tests)
             else:
-                test.score = 0 
+                test.score = 0
             self.results.add(test)
 
     def pytest_terminal_summary(self, terminalreporter):
@@ -198,7 +198,7 @@ def _sanitize_args(args: List[str]) -> List[str]:
     return clean
 
 
-def run(indir: Directory, outdir: Directory, max_score: int, args: List[str]) -> None:
+def run(indir: Directory, outdir: Directory, max_score: float, args: List[str]) -> None:
     """
     Run the tests for the given exercise and produce a results.json.
     """


### PR DESCRIPTION
Tiny code change which allows also to set decimal scores (`float`). I think there is no good reason to limit max_score to only `int`s.